### PR TITLE
Parallel /users/:username endpoint

### DIFF
--- a/apis/apis.go
+++ b/apis/apis.go
@@ -103,7 +103,7 @@ func (a *AnalysisAPI) RunningAnalyses(ctx context.Context, username string, limi
 	return &data, nil
 }
 
-func (a *AnalysisAPI) RunningAnalysesAsync(ctx context.Context, username string, limit int, itemsChan chan *AnalysisListing, errChan chan error) {
+func (a *AnalysisAPI) RunningAnalysesAsync(ctx context.Context, itemsChan chan *AnalysisListing, errChan chan error, username string, limit int) {
 	analyses, err := a.RunningAnalyses(ctx, username, limit)
 	if err != nil {
 		errChan <- err
@@ -164,7 +164,7 @@ func (a *AnalysisAPI) RecentAnalyses(ctx context.Context, username string, limit
 
 }
 
-func (a *AnalysisAPI) RecentAnalysesAsync(ctx context.Context, username string, limit int, itemsChan chan *AnalysisListing, errChan chan error) {
+func (a *AnalysisAPI) RecentAnalysesAsync(ctx context.Context, itemsChan chan *AnalysisListing, errChan chan error, username string, limit int) {
 	analyses, err := a.RecentAnalyses(ctx, username, limit)
 	if err != nil {
 		errChan <- err

--- a/apis/apis.go
+++ b/apis/apis.go
@@ -107,6 +107,7 @@ func (a *AnalysisAPI) RunningAnalysesAsync(ctx context.Context, itemsChan chan *
 	analyses, err := a.RunningAnalyses(ctx, username, limit)
 	if err != nil {
 		errChan <- err
+		return
 	}
 	errChan <- nil
 	itemsChan <- analyses
@@ -168,6 +169,7 @@ func (a *AnalysisAPI) RecentAnalysesAsync(ctx context.Context, itemsChan chan *A
 	analyses, err := a.RecentAnalyses(ctx, username, limit)
 	if err != nil {
 		errChan <- err
+		return
 	}
 	errChan <- nil
 	itemsChan <- analyses

--- a/apis/apis.go
+++ b/apis/apis.go
@@ -97,6 +97,15 @@ func (a *AnalysisAPI) RunningAnalyses(ctx context.Context, username string, limi
 	return &data, nil
 }
 
+func (a *AnalysisAPI) RunningAnalysesAsync(ctx context.Context, username string, limit int, itemsChan chan *AnalysisListing, errChan chan error) {
+	analyses, err := a.RunningAnalyses(ctx, username, limit)
+	if err != nil {
+		errChan <- err
+	}
+	errChan <- nil
+	itemsChan <- analyses
+}
+
 func (a *AnalysisAPI) RecentAnalyses(ctx context.Context, username string, limit int) (*AnalysisListing, error) {
 	log := log.WithField("context", "recent analyses")
 
@@ -144,4 +153,13 @@ func (a *AnalysisAPI) RecentAnalyses(ctx context.Context, username string, limit
 
 	return &data, nil
 
+}
+
+func (a *AnalysisAPI) RecentAnalysesAsync(ctx context.Context, username string, limit int, itemsChan chan *AnalysisListing, errChan chan error) {
+	analyses, err := a.RecentAnalyses(ctx, username, limit)
+	if err != nil {
+		errChan <- err
+	}
+	errChan <- nil
+	itemsChan <- analyses
 }

--- a/apis/apis.go
+++ b/apis/apis.go
@@ -12,10 +12,13 @@ import (
 
 	"github.com/cyverse-de/go-mod/logging"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel"
 )
 
 var log = logging.Log.WithField("package", "apis")
 var httpClient = http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
+
+const otelName = "github.com/cyverse-de/dashboard-aggregator/apis"
 
 type AnalysisListing struct {
 	Analyses []interface{} `json:"analyses"`
@@ -40,6 +43,9 @@ func fixUsername(username string) string {
 }
 
 func (a *AnalysisAPI) RunningAnalyses(ctx context.Context, username string, limit int) (*AnalysisListing, error) {
+	ctx, span := otel.Tracer(otelName).Start(ctx, "RunningAnalyses")
+	defer span.End()
+
 	log := log.WithField("context", "running analyses")
 
 	u := fixUsername(username)
@@ -107,6 +113,9 @@ func (a *AnalysisAPI) RunningAnalysesAsync(ctx context.Context, username string,
 }
 
 func (a *AnalysisAPI) RecentAnalyses(ctx context.Context, username string, limit int) (*AnalysisListing, error) {
+	ctx, span := otel.Tracer(otelName).Start(ctx, "RecentAnalyses")
+	defer span.End()
+
 	log := log.WithField("context", "recent analyses")
 
 	u := fixUsername(username)

--- a/apis/instantlaunches.go
+++ b/apis/instantlaunches.go
@@ -50,7 +50,9 @@ func (i *InstantLaunchesAPI) PullItems(ctx context.Context) ([]map[string]interf
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		resp.Body.Close()
+		if resp != nil {
+			resp.Body.Close()
+		}
 		return nil, err
 	}
 	defer resp.Body.Close()

--- a/apis/instantlaunches.go
+++ b/apis/instantlaunches.go
@@ -82,6 +82,7 @@ func (i *InstantLaunchesAPI) PullItemsAsync(ctx context.Context, itemsChan chan 
 	items, err := i.PullItems(ctx)
 	if err != nil {
 		errChan <- err
+		return
 	}
 	errChan <- nil
 	itemsChan <- items

--- a/apis/instantlaunches.go
+++ b/apis/instantlaunches.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 
 	"github.com/cyverse-de/dashboard-aggregator/config"
+	"go.opentelemetry.io/otel"
 )
 
 type InstantLaunchesAPI struct {
@@ -33,6 +34,9 @@ func NewInstantLaunchesAPI(config *config.ServiceConfiguration) (*InstantLaunche
 }
 
 func (i *InstantLaunchesAPI) PullItems(ctx context.Context) ([]map[string]interface{}, error) {
+	ctx, span := otel.Tracer(otelName).Start(ctx, "PullItems")
+	defer span.End()
+
 	u := i.appExposerURL
 
 	q := u.Query()

--- a/apis/instantlaunches.go
+++ b/apis/instantlaunches.go
@@ -73,3 +73,12 @@ func (i *InstantLaunchesAPI) PullItems(ctx context.Context) ([]map[string]interf
 
 	return items, nil
 }
+
+func (i *InstantLaunchesAPI) PullItemsAsync(ctx context.Context, itemsChan chan []map[string]interface{}, errChan chan error) {
+	items, err := i.PullItems(ctx)
+	if err != nil {
+		errChan <- err
+	}
+	errChan <- nil
+	itemsChan <- items
+}

--- a/apis/metadata.go
+++ b/apis/metadata.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+
+	"go.opentelemetry.io/otel"
 )
 
 type MetadataAPI struct {
@@ -25,6 +27,9 @@ type TargetIDs struct {
 }
 
 func (m *MetadataAPI) GetFilteredTargetIDs(ctx context.Context, username string, targetTypes []string, avus []map[string]string, targetIDs []string) ([]string, error) {
+	ctx, span := otel.Tracer(otelName).Start(ctx, "GetFilteredTargetIDs")
+	defer span.End()
+
 	u := fixUsername(username)
 
 	fullURL := *m.metadataURL.JoinPath("avus", "filter-targets")

--- a/apis/permissions.go
+++ b/apis/permissions.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 
 	"github.com/samber/lo"
+	"go.opentelemetry.io/otel"
 )
 
 type PermissionsAPI struct {
@@ -29,6 +30,9 @@ type PermissionsResponse struct {
 }
 
 func (p *PermissionsAPI) GetPublicIDS(ctx context.Context, publicGroup string) ([]string, error) {
+	ctx, span := otel.Tracer(otelName).Start(ctx, "GetPublicIDS")
+	defer span.End()
+
 	fullURL := *p.permissionsURL
 	fullURL = *fullURL.JoinPath("permissions", "abbreviated", "subjects", "group", publicGroup, "app")
 

--- a/app/app.go
+++ b/app/app.go
@@ -160,7 +160,7 @@ func (a *App) featuredAppIDs(ctx context.Context, username string, publicAppIDs 
 	return featuredAppIDs, nil
 }
 
-func (a *App) featuredAppIDsAsync(ctx context.Context, username string, publicAppIDs []string, idsChan chan []string, errChan chan error) {
+func (a *App) featuredAppIDsAsync(ctx context.Context, idsChan chan []string, errChan chan error, username string, publicAppIDs []string) {
 	featuredAppIDs, err := a.featuredAppIDs(ctx, username, publicAppIDs)
 	if err != nil {
 		errChan <- err

--- a/app/app.go
+++ b/app/app.go
@@ -154,6 +154,15 @@ func (a *App) featuredAppIDs(ctx context.Context, username string, publicAppIDs 
 	return featuredAppIDs, nil
 }
 
+func (a *App) featuredAppIDsAsync(ctx context.Context, username string, publicAppIDs []string, idsChan chan []string, errChan chan error) {
+	featuredAppIDs, err := a.featuredAppIDs(ctx, username, publicAppIDs)
+	if err != nil {
+		errChan <- err
+	}
+	errChan <- nil
+	idsChan <- featuredAppIDs
+}
+
 func (a *App) publicAppIDs(ctx context.Context) ([]string, error) {
 	log := log.WithField("context", "public app ids lookup")
 
@@ -167,4 +176,13 @@ func (a *App) publicAppIDs(ctx context.Context) ([]string, error) {
 	log.Debug("done getting public app ids")
 
 	return publicAppIDs, nil
+}
+
+func (a *App) publicAppIDsAsync(ctx context.Context, idsChan chan []string, errChan chan error) {
+	publicAppIDs, err := a.publicAppIDs(ctx)
+	if err != nil {
+		errChan <- err
+	}
+	errChan <- nil
+	idsChan <- publicAppIDs
 }

--- a/app/app.go
+++ b/app/app.go
@@ -14,9 +14,12 @@ import (
 	"github.com/cyverse-de/go-mod/logging"
 	"github.com/labstack/echo/v4"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho"
+	"go.opentelemetry.io/otel"
 )
 
 var log = logging.Log.WithField("package", "app")
+
+const otelName = "github.com/cyverse-de/dashboard-aggregator/app"
 
 const DefaultStartDateInterval = "1 year"
 const DefaultLimit = int64(10)
@@ -133,6 +136,9 @@ func (a *App) PublicFeedsHandler(c echo.Context) error {
 }
 
 func (a *App) featuredAppIDs(ctx context.Context, username string, publicAppIDs []string) ([]string, error) {
+	ctx, span := otel.Tracer(otelName).Start(ctx, "featuredAppIDs")
+	defer span.End()
+
 	log := log.WithField("context", "featured app ids lookup")
 
 	metadataAPI := apis.NewMetadataAPI(a.metadataURL)
@@ -164,6 +170,9 @@ func (a *App) featuredAppIDsAsync(ctx context.Context, username string, publicAp
 }
 
 func (a *App) publicAppIDs(ctx context.Context) ([]string, error) {
+	ctx, span := otel.Tracer(otelName).Start(ctx, "publicAppIDs")
+	defer span.End()
+
 	log := log.WithField("context", "public app ids lookup")
 
 	permissionsAPI := apis.NewPermissionsAPI(a.permissionsURL)

--- a/app/app.go
+++ b/app/app.go
@@ -161,10 +161,14 @@ func (a *App) featuredAppIDs(ctx context.Context, username string, publicAppIDs 
 }
 
 func (a *App) featuredAppIDsAsync(ctx context.Context, idsChan chan []string, errChan chan error, username string, publicAppIDs []string) {
+	log.Debug("getting featured app IDs (async)")
 	featuredAppIDs, err := a.featuredAppIDs(ctx, username, publicAppIDs)
 	if err != nil {
+		log.Debug("error getting featured app IDs (async)")
 		errChan <- err
+		return
 	}
+	log.Debug("got featured app IDs (async)")
 	errChan <- nil
 	idsChan <- featuredAppIDs
 }
@@ -191,6 +195,7 @@ func (a *App) publicAppIDsAsync(ctx context.Context, idsChan chan []string, errC
 	publicAppIDs, err := a.publicAppIDs(ctx)
 	if err != nil {
 		errChan <- err
+		return
 	}
 	errChan <- nil
 	idsChan <- publicAppIDs

--- a/app/user.go
+++ b/app/user.go
@@ -50,8 +50,8 @@ func (a *App) UserDashboardHandler(c echo.Context) error {
 	runningAnalysisChan := make(chan *apis.AnalysisListing)
 	runningAnalysisErrChan := make(chan error)
 
-	go analysisAPI.RecentAnalysesAsync(ctx, username, int(limit), recentAnalysisChan, recentAnalysisErrChan)
-	go analysisAPI.RunningAnalysesAsync(ctx, username, int(limit), runningAnalysisChan, runningAnalysisErrChan)
+	go analysisAPI.RecentAnalysesAsync(ctx, recentAnalysisChan, recentAnalysisErrChan, username, int(limit))
+	go analysisAPI.RunningAnalysesAsync(ctx, runningAnalysisChan, runningAnalysisErrChan, username, int(limit))
 
 	// Fetch public & featured app IDs
 	publicAppIDsChan := make(chan []string)
@@ -70,7 +70,7 @@ func (a *App) UserDashboardHandler(c echo.Context) error {
 	featuredAppIDsChan := make(chan []string)
 	featuredAppIDsErrChan := make(chan error)
 
-	go a.featuredAppIDsAsync(ctx, username, publicAppIDs, featuredAppIDsChan, featuredAppIDsErrChan)
+	go a.featuredAppIDsAsync(ctx, featuredAppIDsChan, featuredAppIDsErrChan, username, publicAppIDs)
 
 	log.Debug("getting recently added apps")
 	recentlyAddedApps, err := a.db.RecentlyAddedApps(ctx, username, a.config.Apps.FavoritesGroupIndex, publicAppIDs, db.WithQueryLimit(uint(limit)))

--- a/app/user.go
+++ b/app/user.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/cyverse-de/dashboard-aggregator/apis"
@@ -29,42 +30,81 @@ func (a *App) UserDashboardHandler(c echo.Context) error {
 		return err
 	}
 
-	log.Debug("getting instant launch items")
 	ilAPI, err := apis.NewInstantLaunchesAPI(a.config)
 	if err != nil {
 		log.Error(err)
 		return err
 	}
-	ilItems, err := ilAPI.PullItems(ctx)
-	if err != nil {
-		log.Error(err)
-		return err
-	}
-	log.Debug("done getting instant launch items")
+
+	ilChan := make(chan []map[string]interface{})
+	ilErrChan := make(chan error)
+
+	recentAnalysisChan := make(chan *apis.AnalysisListing)
+	recentAnalysisErrChan := make(chan error)
+
+	runningAnalysisChan := make(chan *apis.AnalysisListing)
+	runningAnalysisErrChan := make(chan error)
+
+	publicAppIDsChan := make(chan []string)
+	publicAppIDsErrChan := make(chan error)
+
+	go func(ctx context.Context, ilAPI *apis.InstantLaunchesAPI, ilChan chan []map[string]interface{}, errChan chan error) {
+		log.Debug("getting instant launch items")
+		ilItems, err := ilAPI.PullItems(ctx)
+		if err != nil {
+			log.Error(err)
+			errChan <- err
+		}
+		errChan <- nil
+		ilChan <- ilItems
+		log.Debug("done getting instant launch items")
+	}(ctx, ilAPI, ilChan, ilErrChan)
 
 	analysisAPI := apis.NewAnalysisAPI(a.appsURL)
 
-	log.Debug("getting recent analyses")
-	recentAnalyses, err := analysisAPI.RecentAnalyses(ctx, username, int(limit))
-	if err != nil {
-		log.Error(err)
-		return err
-	}
-	log.Debug("done getting recent analyses")
+	go func(ctx context.Context, analysisAPI *apis.AnalysisAPI, achan chan *apis.AnalysisListing, errChan chan error) {
+		log.Debug("getting recent analyses")
+		recentAnalyses, err := analysisAPI.RecentAnalyses(ctx, username, int(limit))
+		if err != nil {
+			log.Error(err)
+			errChan <- err
+		}
+		errChan <- nil
+		achan <- recentAnalyses
+		log.Debug("done getting recent analyses")
+	}(ctx, analysisAPI, recentAnalysisChan, recentAnalysisErrChan)
 
-	log.Debug("getting running analyses")
-	runningAnalyses, err := analysisAPI.RunningAnalyses(ctx, username, int(limit))
-	if err != nil {
-		log.Error(err)
-		return err
-	}
-	log.Debug("done getting running analyses")
+	go func(ctx context.Context, analysisAPI *apis.AnalysisAPI, achan chan *apis.AnalysisListing, errChan chan error) {
+		log.Debug("getting running analyses")
+		runningAnalyses, err := analysisAPI.RunningAnalyses(ctx, username, int(limit))
+		if err != nil {
+			log.Error(err)
+			errChan <- err
+		}
+		errChan <- nil
+		achan <- runningAnalyses
+		log.Debug("done getting running analyses")
+	}(ctx, analysisAPI, runningAnalysisChan, runningAnalysisErrChan)
 
-	publicAppIDs, err := a.publicAppIDs(ctx)
+	go func(ctx context.Context, idchan chan []string, errChan chan error) {
+		log.Debug("getting public app IDs")
+		publicAppIDs, err := a.publicAppIDs(ctx)
+		if err != nil {
+			log.Error(err)
+			errChan <- err
+		}
+		errChan <- nil
+		idchan <- publicAppIDs
+		log.Debug("done getting public app IDs")
+	}(ctx, publicAppIDsChan, publicAppIDsErrChan)
+
+	// We need public app IDs for the next few calls
+	err = <-publicAppIDsErrChan
 	if err != nil {
 		log.Error(err)
 		return err
 	}
+	publicAppIDs := <-publicAppIDsChan
 
 	log.Debug("getting recently added apps")
 	recentlyAddedApps, err := a.db.RecentlyAddedApps(ctx, username, a.config.Apps.FavoritesGroupIndex, publicAppIDs, db.WithQueryLimit(uint(limit)))
@@ -114,6 +154,28 @@ func (a *App) UserDashboardHandler(c echo.Context) error {
 	log.Debug("done getting featured apps")
 
 	publicFeeds := a.pf
+
+	// Now, check all the channels we still haven't
+	err = <-ilErrChan
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+	ilItems := <-ilChan
+
+	err = <-recentAnalysisErrChan
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+	recentAnalyses := <-recentAnalysisChan
+
+	err = <-runningAnalysisErrChan
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+	runningAnalyses := <-runningAnalysisChan
 
 	retval := map[string]interface{}{
 		"analyses": map[string]interface{}{

--- a/db/db.go
+++ b/db/db.go
@@ -8,12 +8,17 @@ import (
 	"time"
 
 	"github.com/cyverse-de/dashboard-aggregator/config"
+	"github.com/cyverse-de/go-mod/logging"
 	"github.com/doug-martin/goqu/v9"
 	"github.com/jmoiron/sqlx"
 	"github.com/uptrace/opentelemetry-go-extra/otelsql"
 	"github.com/uptrace/opentelemetry-go-extra/otelsqlx"
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 )
+
+const otelName = "github.com/cyverse-de/dashboard-aggregator/apis"
+
+var log = logging.Log.WithField("package", "db")
 
 type GoquDatabase interface {
 	Exec(query string, args ...interface{}) (sql.Result, error)


### PR DESCRIPTION
This should make it so the `/users/:username` endpoint, which is the logged-in dashboard endpoint, does most of its work in parallel instead of serially.